### PR TITLE
minor: check on roleref.name instead of metadata.name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Example:
 set -eux
 
 # Retrieve all subjects with cluster-admin role
-SUBJECTS=$(oc get clusterrolebinding -o json | jq '.items[] | select(.metadata.name |  startswith("cluster-admin")) | .subjects[] | "subject="+.kind+","+"name="+.name')
+SUBJECTS=$(oc get clusterrolebinding -o json | jq '.items[] | select(.roleRef.name |  startswith("cluster-admin")) | .subjects[] | "subject="+.kind+","+"name="+.name')
 
 for subject in $SUBJECTS
 do

--- a/scripts/compliance/subjects_with_admin_role_info.sh
+++ b/scripts/compliance/subjects_with_admin_role_info.sh
@@ -8,7 +8,7 @@
 set -eux
 
 # Retrieve all subjects with admin role
-SUBJECTS=$(oc get rolebinding --all-namespaces -o json | jq 'def getsubjects(data): data | "subject="+.subjects.kind+","+"name="+.subjects.name+","+"namespace="+.namespace; .items[] | select(.metadata.name | startswith("admin")) | getsubjects({"subjects": .subjects[],"namespace": .metadata.namespace})')
+SUBJECTS=$(oc get rolebinding --all-namespaces -o json | jq 'def getsubjects(data): data | "subject="+.subjects.kind+","+"name="+.subjects.name+","+"namespace="+.namespace; .items[] | select(.roleRef.name | test("admin")) | getsubjects({"subjects": .subjects[],"namespace": .metadata.namespace})')
 
 for subject in $SUBJECTS
 do

--- a/scripts/compliance/subjects_with_clusteradmin_role_info.sh
+++ b/scripts/compliance/subjects_with_clusteradmin_role_info.sh
@@ -8,7 +8,7 @@
 set -eux
 
 # Retrieve all subjects with cluster-admin role
-SUBJECTS=$(oc get clusterrolebinding -o json | jq '.items[] | select(.metadata.name |  startswith("cluster-admin")) | .subjects[] | "subject="+.kind+","+"name="+.name')
+SUBJECTS=$(oc get clusterrolebinding -o json | jq '.items[] | select(.roleRef.name |  startswith("cluster-admin")) | .subjects[] | "subject="+.kind+","+"name="+.name')
 
 for subject in $SUBJECTS
 do


### PR DESCRIPTION
because name is free-form ('oc adm policy add-role-to-user cluster-admin MYUSER --rolebinding-name=undercover')
(also, match rolebindings that don't start with admin, but contain the word admin anywhere in their roleref's name)