### PR TITLE
Add more compliance scripts according to CIS Benchmark for Kubernetes

### DIFF
--- a/scripts/compliance/privileged_sccs.sh
+++ b/scripts/compliance/privileged_sccs.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# ACTIVE true
+# TYPE Gauge
+# HELP get all openshift sccs where .allowPrivilegedContainer is set true
+# INTERVAL 60
+
+set -eux
+
+# retrieve all sccs with .allowPrivilegedContainer is set true
+oc get scc -o go-template='{{range .items}}{{if eq .allowPrivilegedContainer true}}1|privileged_scc_name={{.metadata.name}}{{"\n"}}{{end}}{{end}}'
+
+echo "$(date -u +"%s")|lastrun=timestamp"
+
+exit 0

--- a/scripts/compliance/subjects_with_privileged_scc.sh
+++ b/scripts/compliance/subjects_with_privileged_scc.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# ACTIVE true
+# TYPE Gauge
+# HELP get all openshift sccs where .allowPrivilegedContainer is set true
+# INTERVAL 60
+
+set -eux
+
+# retrieve all sccs with .allowPrivilegedContainer is set true
+oc get scc -o go-template='{{range .items}}{{if eq .allowPrivilegedContainer true}}{{$name := .metadata.name}}{{range $user := .users}}1|privileged_scc={{$name}},user={{$user}}{{"\n"}}{{end}}{{range $group := .groups}}1|privileged_scc={{$name}},group={{$group}}{{"\n"}}{{end}}{{end}}{{end}}'
+
+echo "$(date -u +"%s")|lastrun=timestamp"
+
+exit 0

--- a/scripts/compliance/subjects_with_privileged_scc.sh
+++ b/scripts/compliance/subjects_with_privileged_scc.sh
@@ -2,12 +2,12 @@
 
 # ACTIVE true
 # TYPE Gauge
-# HELP get all openshift sccs where .allowPrivilegedContainer is set true
+# HELP get all users and groups in openshift sccs where .allowPrivilegedContainer is set true
 # INTERVAL 60
 
 set -eux
 
-# retrieve all sccs with .allowPrivilegedContainer is set true
+# retrieve all users and groups in sccs with .allowPrivilegedContainer is set true
 oc get scc -o go-template='{{range .items}}{{if eq .allowPrivilegedContainer true}}{{$name := .metadata.name}}{{range $user := .users}}1|privileged_scc={{$name}},user={{$user}}{{"\n"}}{{end}}{{range $group := .groups}}1|privileged_scc={{$name}},group={{$group}}{{"\n"}}{{end}}{{end}}{{end}}'
 
 echo "$(date -u +"%s")|lastrun=timestamp"


### PR DESCRIPTION
Collecting metrics for id 6.9 from https://github.com/aquasecurity/kube-bench/blob/master/cfg/ocp-3.11/master.yaml 